### PR TITLE
#13 feat: pico 2 sdk support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+0.2.1 [10/07/25]
+- Added Pico 2.x.x sdk support to the rp2040 profiles.
+
 0.2.0 [01/07/25]
 * Added support for the following profiles:
 - Linux-armv7hf-gcc-14

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ General Conan configuration for any meen based project.
 This project must be installed as a pre-requsite to building any meen based project.
 ### Install
 To apply these profiles to your local environment:
-`conan config install -sf profiles -tf profiles https://github.com/nbeddows/meen-conan-config.git --args "--branch v0.2.0"`
+`conan config install -sf profiles -tf profiles https://github.com/nbeddows/meen-conan-config.git
 ### Profile customisation
 You may need to tweak the profile for your local or cross compiled environment.

--- a/profiles/rp2040-armv6-gcc-13
+++ b/profiles/rp2040-armv6-gcc-13
@@ -10,14 +10,13 @@ build_type=Release
 [conf]
 tools.build:skip_test=True
 tools.cmake.cmaketoolchain:user_toolchain+={{ profile_dir }}/{{ arch }}-vars.cmake
-# Required for pi pico sdk 2.x
-#tools.build:defines=["__ARM_ARCH_6M__"]
+tools.build:defines=["__ARM_ARCH_6M__"]
 tools.build:cflags=["-mcpu=cortex-m0 -mthumb", "-march=armv6-m"]
 tools.build:cxxflags=["-mcpu=cortex-m0 -mthumb", "-march=armv6-m"]
 [options]
 &:fPIC=False
 &:shared=False
 [buildenv]
-CC=arm-none-eabi-gcc-{{ compiler_version }}.2.1
+CC=arm-none-eabi-gcc-{{ compiler_version }}
 CXX=arm-none-eabi-g++
 LD=arm-none-eabi-ld

--- a/profiles/rp2040-armv6-gcc-14
+++ b/profiles/rp2040-armv6-gcc-14
@@ -10,14 +10,13 @@ build_type=Release
 [conf]
 tools.build:skip_test=True
 tools.cmake.cmaketoolchain:user_toolchain+={{ profile_dir }}/{{ arch }}-vars.cmake
-# Required for pi pico sdk 2.x
-#tools.build:defines=["__ARM_ARCH_6M__"]
+tools.build:defines=["__ARM_ARCH_6M__"]
 tools.build:cflags=["-mcpu=cortex-m0 -mthumb", "-march=armv6-m"]
 tools.build:cxxflags=["-mcpu=cortex-m0 -mthumb", "-march=armv6-m"]
 [options]
 &:fPIC=False
 &:shared=False
 [buildenv]
-CC=arm-none-eabi-gcc-{{ compiler_version }}.2.1
+CC=arm-none-eabi-gcc-{{ compiler_version }}
 CXX=arm-none-eabi-g++
 LD=arm-none-eabi-ld


### PR DESCRIPTION
- Add Pico SDK 2.x.x support (still compatible with SDK 1.5.1) to the rp2040 profiles.
- Remove specific gcc version number from the rp2040 profiles.
- Update the README.
